### PR TITLE
feat: add little-endian pack functions to string.pack module

### DIFF
--- a/src/pkg/string/pack.lua
+++ b/src/pkg/string/pack.lua
@@ -26,9 +26,33 @@ local function u8 (data)
     return ("B"):pack(data)
 end
 
+---Packs 32-bit unsigned integer into a little-endian encoded binary string
+---@param data integer
+---@return string
+local function u32LE (data)
+    return ("<I4"):pack(data)
+end
+
+---Packs 32-bit signed integer into a little-endian encoded binary string
+---@param data integer
+---@return string
+local function i32LE (data)
+    return ("<i4"):pack(data)
+end
+
+---Packs 16-bit unsigned integer into a little-endian encoded binary string
+---@param data integer
+---@return string
+local function u16LE (data)
+    return ("<I2"):pack(data)
+end
+
 return {
     u32BE = u32BE,
     i32BE = i32BE,
     u16BE = u16BE,
     u8 = u8,
+    u32LE = u32LE,
+    i32LE = i32LE,
+    u16LE = u16LE,
 }

--- a/src/pkg/string/pack_test.lua
+++ b/src/pkg/string/pack_test.lua
@@ -47,4 +47,38 @@ describe("pack", function ()
             expect(pack.u8(0xff)):toBe("\xff")
         end)
     end)
+
+    describe("u32LE", function ()
+        test("0", function ()
+            expect(pack.u32LE(0)):toBe("\x00\x00\x00\x00")
+        end)
+
+        test("0x12345678", function ()
+            expect(pack.u32LE(0x12345678)):toBe("\x78\x56\x34\x12")
+        end)
+    end)
+
+    describe("i32LE", function ()
+        test("0", function ()
+            expect(pack.i32LE(0)):toBe("\x00\x00\x00\x00")
+        end)
+
+        test("0x12345678", function ()
+            expect(pack.i32LE(0x12345678)):toBe("\x78\x56\x34\x12")
+        end)
+
+        test("-2", function ()
+            expect(pack.i32LE(-2)):toBe("\xfe\xff\xff\xff")
+        end)
+    end)
+
+    describe("u16LE", function ()
+        test("0", function ()
+            expect(pack.u16LE(0)):toBe("\x00\x00")
+        end)
+
+        test("0x1234", function ()
+            expect(pack.u16LE(0x1234)):toBe("\x34\x12")
+        end)
+    end)
 end)


### PR DESCRIPTION
## Summary
- Add `u32LE`: 32-bit unsigned integer, little-endian
- Add `i32LE`: 32-bit signed integer, little-endian
- Add `u16LE`: 16-bit unsigned integer, little-endian
- Add comprehensive tests for all three functions

## Purpose
These functions complement the existing big-endian functions and are needed for bitmap file format support (BMP files use little-endian byte order).

## Changes
- `src/pkg/string/pack.lua`: Added three new little-endian pack functions with proper type annotations
- `src/pkg/string/pack_test.lua`: Added test cases for all three new functions

## Test Plan
- Run `make test` to verify all tests pass
- Tests verify correct byte ordering for little-endian encoding